### PR TITLE
Add disk space monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ g++ -std=c++14 -O2 watcher.cpp -o watcher -pthread
 
 ## Usage
 ```
-./watcher nginx_access_log_path sleep_second output_json_path
+./watcher nginx_access_log_path sleep_second serve_content_root output_json_path
 ```
 
 Then copy `status.html`, `updatedata.js`, `status.css`, `psd3.min.css`, `psd3.min.js` to the same directory as the json's.

--- a/status.html
+++ b/status.html
@@ -26,6 +26,12 @@
                     <div id="memChart" width="800px" height="300px"></div>
                 </div>
             </div>
+            <div id="diskspace">
+                Disk space:<br>
+                <span id="diskspaceused" style="font-family: monospace"></span> GiB used.<br>
+                <span id="diskspaceavail" style="font-family: monospace"></span> GiB available.
+            </div>
+
             <div id="hotdir">
                 <div id="hotdir-content">
                 </div>

--- a/updatedata.js
+++ b/updatedata.js
@@ -33,6 +33,9 @@ function updateData() {
         });
         memChart.series[1].setData(data.mem.realUsed);
 
+        $("#diskspaceused").text((data.diskSpace.used / 1073741824).toFixed(2));
+        $("#diskspaceavail").text((data.diskSpace.available / 1073741824).toFixed(2));
+
         $("#hotdir-content").html("");
         var config = {
             containerId : "hotdir-content",


### PR DESCRIPTION
Add disk space monitor for a filesystem specified in command line
options. The web frontend can be made more good looking.

In this commit, the command line options change. This may break old
scripts.
